### PR TITLE
Remove firmware version check, bump version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = "Python implementation of the cusb interface for managed USB hubs"
 authors = [{ name = "Gero Schwäricke", email = "gero.schwaericke@posteo.de" }]
 readme = "Readme.md"
 license = "MIT-0"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
     "pyserial == 3.5",  # No information on versioning schema, using fixed version.
     "docopt == 0.6.2",  # Semantic versioning, but not stable yet. Version freeze recommended.

--- a/src/cusb/cusb.py
+++ b/src/cusb/cusb.py
@@ -23,10 +23,6 @@ class CUsb:
 
     def __enter__(self):
         self.s = serial.Serial(self.path, timeout=1)
-        resp = self._send_cmd("?Q")
-        # This code was only tested with this version reported by the hub. If you find a
-        # different version in the field, lmk.
-        assert resp == "CENTOS000104v04", f"Unknown firmware version: {resp}"
         return self
 
     def __exit__(self, type, value, traceback):  # type: ignore


### PR DESCRIPTION
I've tested this library against our newest StarTech hubs which are on a wildly different firmware `CENTOS000207v2`, I think its likely that this utility will work with nearly any of these hubs and restricting its version just makes it harder to use/test.  Requesting removal and a version bump if that's acceptable 😄 